### PR TITLE
Issue 1 - Temporary directories not deleting.

### DIFF
--- a/artifactory_replicator.py
+++ b/artifactory_replicator.py
@@ -155,7 +155,7 @@ class Repository:
 
 
   # Load JSON from file if provided or download if absent.
-  def load_repository_list(self, thread_id = None):
+  def load_repository_list(self):
     if self.repository_list_temp_file == None:
       self.__download_repository_list()
     else:


### PR DESCRIPTION
Deletion of temporary directories triggered from the destructor was abandoned as the "shutil" object turned out to be garbage collected before it could be used to delete. A delete method was added and called from the main run_replication method instead.